### PR TITLE
Fixing typos that cause compilation errors

### DIFF
--- a/android/src/main/java/com/sensormanager/LightSensorRecord.java
+++ b/android/src/main/java/com/sensormanager/LightSensorRecord.java
@@ -36,7 +36,7 @@ public class LightSensorRecord implements SensorEventListener {
 
     public int start(int delay) {
         this.delay = delay;
-        if ((mLightSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)) != nul) {
+        if ((mLightSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)) != null) {
             mSensorManager.registerListener(this, mLightSensor, SensorManager.SENSOR_DELAY_FASTEST);
             return (1);
         }

--- a/android/src/main/java/com/sensormanager/SensorManagerModule.java
+++ b/android/src/main/java/com/sensormanager/SensorManagerModule.java
@@ -131,7 +131,7 @@ public class SensorManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public int stopLightSensor() {
+    public void stopLightSensor() {
       if(mLightSensorRecord != null)
         mLightSensorRecord.stop();
     }


### PR DESCRIPTION
Hi,

thanks for this nice module.
Unfortunately two small typos prevented successful compilation.

First in LightSensorRecord.java:

> node_modules/react-native-sensor-manager/android/src/main/java/com/sensormanager/LightSensorRecord.java:39: error: cannot find symbol
>         if ((mLightSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)) != nul) {
>                                                                                    ^
>   symbol:   variable nul
>   location: class LightSensorRecord
> 1 error
>  FAILED
> 
> FAILURE: Build failed with an exception.
> - What went wrong:
>   Execution failed for task ':react-native-sensor-manager:compileReleaseJavaWithJavac'.
>   > Compilation failed; see the compiler error output for details.

Second in SensorManagerModule.java:

> node_modules/react-native-sensor-manager/android/src/main/java/com/sensormanager/SensorManagerModule.java:137: error: missing return statement
>     }
>     ^
> 1 error
>  FAILED
> 
> FAILURE: Build failed with an exception.
> - What went wrong:
>   Execution failed for task ':react-native-sensor-manager:compileReleaseJavaWithJavac'.
>   > Compilation failed; see the compiler error output for details.

This pull request fixes  both typos.
