### PR TITLE
Make the proximity sensor a first-class feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,17 @@ DeviceEventEmitter.addListener('LightSensor', function (data) {
 });
 mSensorManager.stopLightSensor();
 ```
+
+
+### Proximity Sensor
+```js
+mSensorManager.startProximity(100);
+DeviceEventEmitter.addListener('Proximity', function (data) {
+  /**
+  * data.isNear: [Boolean] A flag representing whether something is near the screen.
+  * data.value: [Number] The raw value returned by the sensor (usually distance in cm).
+  * data.maxRange: [Number] The maximum range of the sensor.
+  **/
+});
+mSensorManager.stopProximity();
+```

--- a/android/src/main/java/com/sensormanager/SensorManagerModule.java
+++ b/android/src/main/java/com/sensormanager/SensorManagerModule.java
@@ -112,14 +112,14 @@ public class SensorManagerModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public int startProximity(int delay) {
-		if (mMotionValueRecord == null)
+		if (mProximityRecord == null)
 			mProximityRecord = new ProximityRecord(mReactContext);
 		return (mProximityRecord.start(delay));
     }
 
     @ReactMethod
     public void stopProximity() {
-		if (mMotionValueRecord != null)
+		if (mProximityRecord != null)
 			mProximityRecord.stop();
     }
 


### PR DESCRIPTION
I've made a few changes to improve the usability of the Proximity sensor:
- Added documentation to the README
- Fixed a bug which caused the sensor to be initialized many times
- Provided access to raw sensor values, since the heuristic `isNear` isn't always suitable

The changes have been tested on a Moto G 3 using React Native 0.26.2
